### PR TITLE
Add mobile view toggle for game and controls

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,109 +6,147 @@ import { setupUI } from './ui'
 const app = document.querySelector<HTMLDivElement>('#app')!
 
 app.innerHTML = `
-  <div id="gameParent"></div>
-  <div id="sidebar">
-    <h1 class="title">Elevator Simulator</h1>
-    <div class="section">
-      <div class="grid-two">
-        <div>
-          <label for="floors">Floors</label>
-          <input id="floors" type="number" min="2" max="50" value="10"/>
+  <div id="mobileViewToggle" class="mobile-toggle">
+    <button type="button" data-view="game" class="active">Simulation</button>
+    <button type="button" data-view="sidebar">Controls</button>
+  </div>
+  <div class="app-layout">
+    <div id="gameParent"></div>
+    <div id="sidebar">
+      <h1 class="title">Elevator Simulator</h1>
+      <div class="section">
+        <div class="grid-two">
+          <div>
+            <label for="floors">Floors</label>
+            <input id="floors" type="number" min="2" max="50" value="10"/>
+          </div>
+          <div>
+            <label for="elevators">Elevators</label>
+            <input id="elevators" type="number" min="1" max="16" value="3"/>
+          </div>
         </div>
-        <div>
-          <label for="elevators">Elevators</label>
-          <input id="elevators" type="number" min="1" max="16" value="3"/>
+        <div class="row">
+          <label for="spawnRate">Spawn Rate (ppl/min)</label>
+          <input id="spawnRate" type="range" min="0" max="200" value="40"/>
         </div>
-      </div>
-      <div class="row">
-        <label for="spawnRate">Spawn Rate (ppl/min)</label>
-        <input id="spawnRate" type="range" min="0" max="200" value="40"/>
-      </div>
-      <div class="row">
-        <label></label>
-        <div class="small" id="spawnRateLabel">40 ppl/min</div>
-      </div>
-      <div class="row">
-        <label for="algorithm">Algorithm</label>
-        <select id="algorithm">
-          <option value="nearest">Nearest Car</option>
-          <option value="exclusiveNearest">Single Responder (Nearest)</option>
-          <option value="collective">Collective (Simple)</option>
-          <option value="zoned">Zoned (Sectorized)</option>
-          <option value="idleLobby">Idle To Lobby</option>
-          <option value="custom">Custom (Editor)</option>
-        </select>
-      </div>
-      <div class="row">
-        <button id="apply" class="primary">Apply & Restart</button>
-        <button id="pause">Pause</button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h1 class="title">Crowd Model</h1>
-      <div class="row">
-        <label for="groundBias">Ground Floor Bias</label>
-        <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
-      </div>
-      <div class="row"><label></label><div id="groundBiasLabel" class="small">x3.0</div></div>
-      <div class="row">
-        <label for="toLobbyPct">To Lobby Preference</label>
-        <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
-      </div>
-      <div class="row"><label></label><div id="toLobbyPctLabel" class="small">70%</div></div>
-    </div>
-
-    <div class="section">
-      <h1 class="title">Manual Call</h1>
-      <div class="grid-two">
-        <div>
-          <label for="manualFloor">Floor</label>
-          <input id="manualFloor" type="number" min="0" max="49" value="0"/>
+        <div class="row">
+          <label></label>
+          <div class="small" id="spawnRateLabel">40 ppl/min</div>
         </div>
-        <div>
-          <label for="manualDir">Direction</label>
-          <select id="manualDir">
-            <option value="up">Up</option>
-            <option value="down">Down</option>
+        <div class="row">
+          <label for="algorithm">Algorithm</label>
+          <select id="algorithm">
+            <option value="nearest">Nearest Car</option>
+            <option value="exclusiveNearest">Single Responder (Nearest)</option>
+            <option value="collective">Collective (Simple)</option>
+            <option value="zoned">Zoned (Sectorized)</option>
+            <option value="idleLobby">Idle To Lobby</option>
+            <option value="custom">Custom (Editor)</option>
           </select>
         </div>
+        <div class="row">
+          <button id="apply" class="primary">Apply & Restart</button>
+          <button id="pause">Pause</button>
+        </div>
       </div>
-      <div class="row">
-        <button id="manualCall" class="primary">Call Elevator</button>
-      </div>
-    </div>
 
-    <div class="section" id="customEditorSection" style="display:none;">
-      <div class="small" style="margin-bottom:6px;">
-        Provide a JS function named <code>decide</code> taking a state object and returning decisions.
+      <div class="section">
+        <h1 class="title">Crowd Model</h1>
+        <div class="row">
+          <label for="groundBias">Ground Floor Bias</label>
+          <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
+        </div>
+        <div class="row"><label></label><div id="groundBiasLabel" class="small">x3.0</div></div>
+        <div class="row">
+          <label for="toLobbyPct">To Lobby Preference</label>
+          <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
+        </div>
+        <div class="row"><label></label><div id="toLobbyPctLabel" class="small">70%</div></div>
       </div>
-      <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
-      <div class="row">
-        <button id="loadCustom" class="primary">Load Custom Algorithm</button>
+
+      <div class="section">
+        <h1 class="title">Manual Call</h1>
+        <div class="grid-two">
+          <div>
+            <label for="manualFloor">Floor</label>
+            <input id="manualFloor" type="number" min="0" max="49" value="0"/>
+          </div>
+          <div>
+            <label for="manualDir">Direction</label>
+            <select id="manualDir">
+              <option value="up">Up</option>
+              <option value="down">Down</option>
+            </select>
+          </div>
+        </div>
+        <div class="row">
+          <button id="manualCall" class="primary">Call Elevator</button>
+        </div>
       </div>
-    </div>
 
-    <div class="section">
-      <div class="stats">
-        <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
-        <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
-        <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
-        <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
+      <div class="section" id="customEditorSection" style="display:none;">
+        <div class="small" style="margin-bottom:6px;">
+          Provide a JS function named <code>decide</code> taking a state object and returning decisions.
+        </div>
+        <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
+        <div class="row">
+          <button id="loadCustom" class="primary">Load Custom Algorithm</button>
+        </div>
       </div>
-    </div>
 
-    <div class="section">
-      <h1 class="title">Fleet</h1>
-      <div id="fleetList" class="fleet-list"></div>
-    </div>
+      <div class="section">
+        <div class="stats">
+          <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
+          <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
+          <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
+          <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
+        </div>
+      </div>
 
-    <div class="section">
-      <h1 class="title">Floor Calls</h1>
-      <div id="floorCalls" class="floor-calls"></div>
+      <div class="section">
+        <h1 class="title">Fleet</h1>
+        <div id="fleetList" class="fleet-list"></div>
+      </div>
+
+      <div class="section">
+        <h1 class="title">Floor Calls</h1>
+        <div id="floorCalls" class="floor-calls"></div>
+      </div>
     </div>
   </div>
 `
+
+type MobileView = 'game' | 'sidebar'
+
+let phaserGame: Phaser.Game | undefined
+
+const toggleContainer = app.querySelector<HTMLDivElement>('#mobileViewToggle')
+const toggleButtons = toggleContainer
+  ? Array.from(toggleContainer.querySelectorAll<HTMLButtonElement>('button[data-view]'))
+  : []
+
+const setMobileView = (view: MobileView) => {
+  app.dataset.mobileView = view
+  toggleButtons.forEach((btn) => {
+    btn.classList.toggle('active', btn.dataset.view === view)
+  })
+  if (view === 'game' && phaserGame) {
+    // Phaser may need a refresh after the canvas was hidden.
+    setTimeout(() => phaserGame?.scale.refresh(), 0)
+  }
+}
+
+if (toggleButtons.length) {
+  toggleButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const view = (btn.dataset.view === 'sidebar' ? 'sidebar' : 'game') as MobileView
+      setMobileView(view)
+    })
+  })
+  setMobileView('game')
+} else {
+  app.dataset.mobileView = 'game'
+}
 
 const game = new Phaser.Game({
   type: Phaser.AUTO,
@@ -124,5 +162,7 @@ const game = new Phaser.Game({
   render: { pixelArt: false, antialias: true },
   scene: [GameScene],
 })
+
+phaserGame = game
 
 setupUI(game)

--- a/src/style.css
+++ b/src/style.css
@@ -24,10 +24,10 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background: #0f1216;
+  color: #e7ecf3;
 }
 
 h1 {
@@ -99,13 +99,47 @@ button:focus-visible {
 html, body, #app { height: 100%; }
 
 #app {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+}
+
+.app-layout {
+  flex: 1;
   display: grid;
   grid-template-columns: 1fr 340px;
   grid-template-rows: 100%;
   gap: 0;
   height: 100%;
-  max-width: none;
-  padding: 0;
+  min-height: 0;
+}
+
+#mobileViewToggle {
+  display: none;
+  gap: 8px;
+  padding: 12px;
+  background: #11151b;
+  border-bottom: 1px solid #1f2630;
+}
+
+#mobileViewToggle button {
+  flex: 1 1 0;
+  width: auto;
+  background: #11151b;
+  border-color: #2a2f3a;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 14px;
+}
+
+#mobileViewToggle button.active {
+  background: #173047;
+  border-color: #21435e;
 }
 
 #gameParent {
@@ -121,6 +155,39 @@ html, body, #app { height: 100%; }
   padding: 14px 14px 100px;
   overflow: auto;
   text-align: left;
+}
+
+@media (max-width: 900px) {
+  .app-layout {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .app-layout > #gameParent,
+  .app-layout > #sidebar {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  #mobileViewToggle {
+    display: flex;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  #app[data-mobile-view='game'] #sidebar {
+    display: none;
+  }
+
+  #app[data-mobile-view='sidebar'] #gameParent {
+    display: none;
+  }
+
+  #sidebar {
+    border-left: none;
+    border-top: 1px solid #1f2630;
+  }
 }
 
 h1.title {


### PR DESCRIPTION
## Summary
- add a mobile view toggle that lets users switch between the simulation and control panel
- refresh the Phaser canvas when returning to the simulation so it resizes correctly
- update styles to support the new layout and responsive behaviour on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf687a6cd883268b13da78159d8178