### PR TITLE
Add mobile view toggle for game and controls

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,8 +4,13 @@ import { GameScene } from './scenes/GameScene'
 import { setupUI } from './ui'
 
 const app = document.querySelector<HTMLDivElement>('#app')!
+app.classList.add('show-game')
 
 app.innerHTML = `
+  <div id="mobileToggle" class="mobile-toggle" aria-label="View selection">
+    <button type="button" data-target="game" aria-pressed="true">Elevators</button>
+    <button type="button" data-target="sidebar" aria-pressed="false">Controls</button>
+  </div>
   <div id="gameParent"></div>
   <div id="sidebar">
     <h1 class="title">Elevator Simulator</h1>
@@ -126,3 +131,27 @@ const game = new Phaser.Game({
 })
 
 setupUI(game)
+
+const mobileToggle = document.getElementById('mobileToggle')
+if (mobileToggle) {
+  const buttons = Array.from(mobileToggle.querySelectorAll<HTMLButtonElement>('button[data-target]'))
+  type Panel = 'game' | 'sidebar'
+  const setPanel = (panel: Panel) => {
+    app.classList.remove('show-game', 'show-sidebar')
+    app.classList.add(panel === 'game' ? 'show-game' : 'show-sidebar')
+    buttons.forEach((btn) => {
+      const isActive = btn.dataset.target === panel
+      btn.classList.toggle('active', isActive)
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false')
+    })
+  }
+
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const target = (btn.dataset.target as Panel) || 'game'
+      setPanel(target)
+    })
+  })
+
+  setPanel('game')
+}

--- a/src/style.css
+++ b/src/style.css
@@ -123,6 +123,25 @@ html, body, #app { height: 100%; }
   text-align: left;
 }
 
+.mobile-toggle {
+  display: none;
+}
+
+.mobile-toggle button {
+  flex: 1;
+  border: 1px solid #2a2f3a;
+  background: #11151b;
+  color: #e7ecf3;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.mobile-toggle button.active {
+  background: #173047;
+  border-color: #21435e;
+}
+
 h1.title {
   font-size: 18px;
   margin: 0 0 12px;
@@ -221,3 +240,37 @@ button.primary:hover { background: #183650; }
 .badge { border:1px solid #2a2f3a; border-radius:999px; padding:2px 8px; font-size:12px; }
 .badge.up { color:#58d68d; }
 .badge.down { color:#ff6b6b; }
+
+@media (max-width: 900px) {
+  #app {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+
+  .mobile-toggle {
+    display: flex;
+    gap: 8px;
+    grid-column: 1 / -1;
+    padding: 10px 14px;
+    background: #151a21;
+    border-bottom: 1px solid #1f2630;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
+
+  #gameParent,
+  #sidebar {
+    grid-column: 1 / -1;
+  }
+
+  #gameParent,
+  #sidebar {
+    display: none;
+  }
+
+  #app.show-game #gameParent,
+  #app.show-sidebar #sidebar {
+    display: block;
+  }
+}


### PR DESCRIPTION
## Summary
- add a mobile toggle control to switch between the game canvas and sidebar
- wire up toggle interactions with ARIA pressed states for accessibility feedback
- introduce responsive styles so only the selected panel is visible on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf687a6cd883268b13da78159d8178