### PR TITLE
Fix PR preview workflow permissions for comments

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,8 @@ jobs:
   deploy-preview:
     permissions:
       contents: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant the PR preview workflow the additional permissions it needs to leave sticky comments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf6c47a48483269a022c0b55e13aad