### PR TITLE
Add mobile tabbed layout for simulator

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,109 +6,186 @@ import { setupUI } from './ui'
 const app = document.querySelector<HTMLDivElement>('#app')!
 
 app.innerHTML = `
-  <div id="gameParent"></div>
-  <div id="sidebar">
-    <h1 class="title">Elevator Simulator</h1>
-    <div class="section">
-      <div class="grid-two">
-        <div>
-          <label for="floors">Floors</label>
-          <input id="floors" type="number" min="2" max="50" value="10"/>
+  <div id="gamePanel" data-panel="game" class="active">
+    <div id="gameParent"></div>
+  </div>
+  <aside id="sidebar">
+    <div id="setupPanel" class="sidebar-group active" data-panel="setup">
+      <h1 class="title main-title">Elevator Simulator</h1>
+      <div class="section">
+        <div class="grid-two">
+          <div>
+            <label for="floors">Floors</label>
+            <input id="floors" type="number" min="2" max="50" value="10"/>
+          </div>
+          <div>
+            <label for="elevators">Elevators</label>
+            <input id="elevators" type="number" min="1" max="16" value="3"/>
+          </div>
         </div>
-        <div>
-          <label for="elevators">Elevators</label>
-          <input id="elevators" type="number" min="1" max="16" value="3"/>
+        <div class="row">
+          <label for="spawnRate">Spawn Rate (ppl/min)</label>
+          <input id="spawnRate" type="range" min="0" max="200" value="40"/>
         </div>
-      </div>
-      <div class="row">
-        <label for="spawnRate">Spawn Rate (ppl/min)</label>
-        <input id="spawnRate" type="range" min="0" max="200" value="40"/>
-      </div>
-      <div class="row">
-        <label></label>
-        <div class="small" id="spawnRateLabel">40 ppl/min</div>
-      </div>
-      <div class="row">
-        <label for="algorithm">Algorithm</label>
-        <select id="algorithm">
-          <option value="nearest">Nearest Car</option>
-          <option value="exclusiveNearest">Single Responder (Nearest)</option>
-          <option value="collective">Collective (Simple)</option>
-          <option value="zoned">Zoned (Sectorized)</option>
-          <option value="idleLobby">Idle To Lobby</option>
-          <option value="custom">Custom (Editor)</option>
-        </select>
-      </div>
-      <div class="row">
-        <button id="apply" class="primary">Apply & Restart</button>
-        <button id="pause">Pause</button>
-      </div>
-    </div>
-
-    <div class="section">
-      <h1 class="title">Crowd Model</h1>
-      <div class="row">
-        <label for="groundBias">Ground Floor Bias</label>
-        <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
-      </div>
-      <div class="row"><label></label><div id="groundBiasLabel" class="small">x3.0</div></div>
-      <div class="row">
-        <label for="toLobbyPct">To Lobby Preference</label>
-        <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
-      </div>
-      <div class="row"><label></label><div id="toLobbyPctLabel" class="small">70%</div></div>
-    </div>
-
-    <div class="section">
-      <h1 class="title">Manual Call</h1>
-      <div class="grid-two">
-        <div>
-          <label for="manualFloor">Floor</label>
-          <input id="manualFloor" type="number" min="0" max="49" value="0"/>
+        <div class="row">
+          <label aria-hidden="true"></label>
+          <div class="small" id="spawnRateLabel">40 ppl/min</div>
         </div>
-        <div>
-          <label for="manualDir">Direction</label>
-          <select id="manualDir">
-            <option value="up">Up</option>
-            <option value="down">Down</option>
+        <div class="row">
+          <label for="algorithm">Algorithm</label>
+          <select id="algorithm">
+            <option value="nearest">Nearest Car</option>
+            <option value="exclusiveNearest">Single Responder (Nearest)</option>
+            <option value="collective">Collective (Simple)</option>
+            <option value="zoned">Zoned (Sectorized)</option>
+            <option value="idleLobby">Idle To Lobby</option>
+            <option value="custom">Custom (Editor)</option>
           </select>
         </div>
+        <div class="row actions-row">
+          <button id="apply" class="primary">Apply & Restart</button>
+          <button id="pause">Pause</button>
+        </div>
       </div>
-      <div class="row">
-        <button id="manualCall" class="primary">Call Elevator</button>
+
+      <div class="section">
+        <h1 class="title">Crowd Model</h1>
+        <div class="row">
+          <label for="groundBias">Ground Floor Bias</label>
+          <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
+        </div>
+        <div class="row">
+          <label aria-hidden="true"></label>
+          <div id="groundBiasLabel" class="small">x3.0</div>
+        </div>
+        <div class="row">
+          <label for="toLobbyPct">To Lobby Preference</label>
+          <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
+        </div>
+        <div class="row">
+          <label aria-hidden="true"></label>
+          <div id="toLobbyPctLabel" class="small">70%</div>
+        </div>
+      </div>
+
+      <div class="section">
+        <h1 class="title">Manual Call</h1>
+        <div class="grid-two">
+          <div>
+            <label for="manualFloor">Floor</label>
+            <input id="manualFloor" type="number" min="0" max="49" value="0"/>
+          </div>
+          <div>
+            <label for="manualDir">Direction</label>
+            <select id="manualDir">
+              <option value="up">Up</option>
+              <option value="down">Down</option>
+            </select>
+          </div>
+        </div>
+        <div class="row actions-row">
+          <button id="manualCall" class="primary">Call Elevator</button>
+        </div>
+      </div>
+
+      <div class="section" id="customEditorSection" style="display:none;">
+        <div class="small" style="margin-bottom:6px;">
+          Provide a JS function named <code>decide</code> taking a state object and returning decisions.
+        </div>
+        <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
+        <div class="row actions-row">
+          <button id="loadCustom" class="primary">Load Custom Algorithm</button>
+        </div>
       </div>
     </div>
 
-    <div class="section" id="customEditorSection" style="display:none;">
-      <div class="small" style="margin-bottom:6px;">
-        Provide a JS function named <code>decide</code> taking a state object and returning decisions.
+    <div id="insightsPanel" class="sidebar-group" data-panel="insights">
+      <div class="section">
+        <h1 class="title">Simulation Stats</h1>
+        <div class="stats">
+          <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
+          <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
+          <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
+          <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
+        </div>
       </div>
-      <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
-      <div class="row">
-        <button id="loadCustom" class="primary">Load Custom Algorithm</button>
+
+      <div class="section">
+        <h1 class="title">Fleet</h1>
+        <div id="fleetList" class="fleet-list"></div>
+      </div>
+
+      <div class="section">
+        <h1 class="title">Floor Calls</h1>
+        <div id="floorCalls" class="floor-calls"></div>
       </div>
     </div>
-
-    <div class="section">
-      <div class="stats">
-        <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
-        <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
-        <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
-        <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
-      </div>
-    </div>
-
-    <div class="section">
-      <h1 class="title">Fleet</h1>
-      <div id="fleetList" class="fleet-list"></div>
-    </div>
-
-    <div class="section">
-      <h1 class="title">Floor Calls</h1>
-      <div id="floorCalls" class="floor-calls"></div>
-    </div>
-  </div>
+  </aside>
+  <nav id="mobileTabBar" class="mobile-tabs" aria-label="Simulator navigation" role="tablist">
+    <button class="mobile-tab active" data-tab="game" role="tab" aria-selected="true" aria-controls="gamePanel">Game</button>
+    <button class="mobile-tab" data-tab="setup" role="tab" aria-selected="false" aria-controls="setupPanel">Controls</button>
+    <button class="mobile-tab" data-tab="insights" role="tab" aria-selected="false" aria-controls="insightsPanel">Insights</button>
+  </nav>
 `
+
+const panels = Array.from(document.querySelectorAll<HTMLElement>('[data-panel]'))
+const tabs = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-tab]'))
+const sidebar = document.getElementById('sidebar')!
+const mobileQuery = window.matchMedia('(max-width: 900px)')
+
+function activateTab(panelId: string) {
+  panels.forEach(panel => {
+    panel.classList.toggle('active', panel.dataset.panel === panelId)
+  })
+
+  tabs.forEach(tab => {
+    const isActive = tab.dataset.tab === panelId
+    tab.classList.toggle('active', isActive)
+    tab.setAttribute('aria-selected', isActive ? 'true' : 'false')
+  })
+
+  if (mobileQuery.matches) {
+    if (panelId === 'game') {
+      sidebar.classList.remove('mobile-visible')
+      requestAnimationFrame(() => {
+        window.dispatchEvent(new Event('resize'))
+      })
+    } else {
+      sidebar.classList.add('mobile-visible')
+    }
+  }
+}
+
+function handleViewportChange() {
+  if (!mobileQuery.matches) {
+    sidebar.classList.remove('mobile-visible')
+    panels.forEach(panel => {
+      panel.classList.add('active')
+    })
+    return
+  }
+
+  const activeTabId = tabs.find(tab => tab.classList.contains('active'))?.dataset.tab ?? 'game'
+  activateTab(activeTabId)
+}
+
+tabs.forEach(tab => {
+  tab.addEventListener('click', () => {
+    const target = tab.dataset.tab
+    if (target) {
+      activateTab(target)
+    }
+  })
+})
+
+activateTab('game')
+handleViewportChange()
+
+if (typeof mobileQuery.addEventListener === 'function') {
+  mobileQuery.addEventListener('change', handleViewportChange)
+} else {
+  mobileQuery.addListener(handleViewportChange)
+}
 
 const game = new Phaser.Game({
   type: Phaser.AUTO,

--- a/src/style.css
+++ b/src/style.css
@@ -1,111 +1,84 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.4;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #e7ecf3;
+  background-color: #0f1216;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color-scheme: dark;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
 }
 
 a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+  color: #7aa6ff;
+  text-decoration: none;
 }
+
 a:hover {
-  color: #535bf2;
+  color: #9bbdff;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-#app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vanilla:hover {
-  filter: drop-shadow(0 0 2em #3178c6aa);
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  background: #0f1216;
+  color: inherit;
+  font-size: 14px;
 }
 
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: 1px solid #2a2f3a;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #11151b;
+  color: inherit;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 200ms ease, border-color 200ms ease;
 }
+
 button:hover {
-  border-color: #646cff;
+  border-color: #3a4a5c;
 }
+
 button:focus,
 button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  outline: 2px solid #5b9bff;
+  outline-offset: 2px;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button.primary {
+  background: #173047;
+  border-color: #21435e;
 }
 
-/* App layout overrides for the simulator */
-html, body, #app { height: 100%; }
+button.primary:hover {
+  background: #183650;
+}
+
+html, body, #app {
+  height: 100%;
+}
 
 #app {
-  display: grid;
-  grid-template-columns: 1fr 340px;
-  grid-template-rows: 100%;
-  gap: 0;
-  height: 100%;
+  width: 100%;
   max-width: none;
-  padding: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  grid-template-rows: 100%;
+  background: #0f1216;
+}
+
+#gamePanel {
+  position: relative;
+  min-height: 0;
 }
 
 #gameParent {
@@ -113,34 +86,87 @@ html, body, #app { height: 100%; }
   width: 100%;
   height: 100%;
   overflow: hidden;
+  background: #0f1216;
 }
 
 #sidebar {
   background: #151a21;
   border-left: 1px solid #1f2630;
-  padding: 14px 14px 100px;
-  overflow: auto;
-  text-align: left;
+  padding: 18px 18px 32px;
+  overflow-y: auto;
+}
+
+.sidebar-group + .sidebar-group {
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px solid #1f2630;
 }
 
 h1.title {
   font-size: 18px;
+  line-height: 1.3;
   margin: 0 0 12px;
 }
 
-.section { margin-bottom: 16px; }
+.title.main-title {
+  font-size: 20px;
+  margin-bottom: 20px;
+}
+
+.section {
+  margin-bottom: 18px;
+}
+
+.section:last-child {
+  margin-bottom: 0;
+}
+
+label {
+  color: #a5b0bf;
+  font-size: 12px;
+}
 
 .row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 8px;
-  margin: 8px 0;
+  gap: 10px;
+  margin: 10px 0;
+  flex-wrap: wrap;
 }
 
-label { color: #a5b0bf; font-size: 12px; }
+.row label {
+  flex: 1 0 120px;
+}
 
-input[type="range"], select, button, input[type="number"], textarea {
+.row > *:not(label) {
+  flex: 2 1 180px;
+}
+
+.row.actions-row {
+  justify-content: flex-start;
+}
+
+.row.actions-row button {
+  flex: 1 1 50%;
+}
+
+.grid-two {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.small {
+  font-size: 12px;
+  color: #a5b0bf;
+}
+
+input[type="range"],
+select,
+button,
+input[type="number"],
+textarea {
   width: 100%;
   background: #11151b;
   color: #e7ecf3;
@@ -150,15 +176,15 @@ input[type="range"], select, button, input[type="number"], textarea {
   font: inherit;
 }
 
-input[type="range"] { padding: 0; }
-button { cursor: pointer; }
-button.primary { background: #173047; border-color: #21435e; }
-button.primary:hover { background: #183650; }
+input[type="range"] {
+  padding: 0;
+}
 
-.grid-two {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
+textarea.code-editor {
+  min-height: 160px;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
 }
 
 .stats {
@@ -166,40 +192,40 @@ button.primary:hover { background: #183650; }
   grid-template-columns: 1fr 1fr;
   gap: 10px;
 }
+
 .stat {
   background: #11151b;
   border: 1px solid #2a2f3a;
   border-radius: 6px;
-  padding: 10px;
-}
-.stat .label { color: #a5b0bf; font-size: 11px; }
-.stat .value { font-size: 16px; margin-top: 4px; }
-
-.danger { color: #ff6b6b; }
-.ok { color: #58d68d; }
-.warn { color: #ffd166; }
-.small { font-size: 12px; color: #a5b0bf; }
-
-.code-editor {
-  width: 100%;
-  min-height: 160px;
-  resize: vertical;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  padding: 12px;
 }
 
-/* Fleet list */
-.fleet-list { display: grid; gap: 6px; }
+.stat .label {
+  color: #a5b0bf;
+  font-size: 11px;
+}
+
+.stat .value {
+  font-size: 16px;
+  margin-top: 4px;
+}
+
+.fleet-list {
+  display: grid;
+  gap: 8px;
+}
+
 .fleet-row {
   display: grid;
-  grid-template-columns: 38px 1fr 56px 64px;
+  grid-template-columns: 38px 1fr 70px 1fr;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   background: #11151b;
   border: 1px solid #2a2f3a;
   border-radius: 6px;
   padding: 8px;
 }
+
 .chip {
   background: #0d1117;
   border: 1px solid #2a2f3a;
@@ -209,15 +235,206 @@ button.primary:hover { background: #183650; }
   color: #e7ecf3;
   text-align: center;
 }
-.dir-up { color: #58d68d; }
-.dir-down { color: #ff6b6b; }
-.dir-idle { color: #a5b0bf; }
 
-.bar { background:#0b0e13; border:1px solid #2a2f3a; border-radius:4px; height:10px; overflow:hidden; }
-.bar-fill { background:#ffd166; height:100%; width:0%; }
+.dir-up {
+  color: #58d68d;
+}
 
-.floor-calls { display:grid; gap:6px; }
-.call-row { display:flex; justify-content:space-between; align-items:center; background:#11151b; border:1px solid #2a2f3a; border-radius:6px; padding:6px 8px; }
-.badge { border:1px solid #2a2f3a; border-radius:999px; padding:2px 8px; font-size:12px; }
-.badge.up { color:#58d68d; }
-.badge.down { color:#ff6b6b; }
+.dir-down {
+  color: #ff6b6b;
+}
+
+.dir-idle {
+  color: #a5b0bf;
+}
+
+.bar {
+  background: #0b0e13;
+  border: 1px solid #2a2f3a;
+  border-radius: 4px;
+  height: 10px;
+  overflow: hidden;
+}
+
+.bar-fill {
+  background: #ffd166;
+  height: 100%;
+  width: 0%;
+}
+
+.floor-calls {
+  display: grid;
+  gap: 6px;
+}
+
+.call-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #11151b;
+  border: 1px solid #2a2f3a;
+  border-radius: 6px;
+  padding: 6px 8px;
+}
+
+.badge {
+  border: 1px solid #2a2f3a;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 12px;
+}
+
+.badge.up {
+  color: #58d68d;
+}
+
+.badge.down {
+  color: #ff6b6b;
+}
+
+.danger {
+  color: #ff6b6b;
+}
+
+.ok {
+  color: #58d68d;
+}
+
+.warn {
+  color: #ffd166;
+}
+
+#mobileTabBar {
+  display: none;
+}
+
+.mobile-tab {
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: #11151b;
+  border: 1px solid #2a2f3a;
+  color: #e7ecf3;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.mobile-tab.active {
+  background: #173047;
+  border-color: #21435e;
+}
+
+@media (max-width: 900px) {
+  #app {
+    display: flex;
+    flex-direction: column;
+  }
+
+  #gamePanel {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: none;
+  }
+
+  #gamePanel.active {
+    display: block;
+  }
+
+  #sidebar {
+    display: none;
+    border-left: none;
+    border-top: 1px solid #1f2630;
+    padding: 20px 16px calc(24px + env(safe-area-inset-bottom));
+    flex: 1 1 auto;
+    overflow-y: auto;
+  }
+
+  #sidebar.mobile-visible {
+    display: block;
+  }
+
+  .sidebar-group {
+    display: none;
+  }
+
+  .sidebar-group.active {
+    display: block;
+  }
+
+  .sidebar-group + .sidebar-group {
+    margin-top: 0;
+    padding-top: 0;
+    border-top: none;
+  }
+
+  .title.main-title {
+    font-size: 18px;
+  }
+
+  .grid-two {
+    grid-template-columns: 1fr;
+  }
+
+  .row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .row label,
+  .row > *:not(label) {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .row.actions-row {
+    gap: 8px;
+  }
+
+  .row.actions-row button {
+    width: 100%;
+  }
+
+  .stats {
+    grid-template-columns: 1fr;
+  }
+
+  .fleet-row {
+    grid-template-columns: 38px 1fr;
+    grid-template-rows: auto auto;
+    row-gap: 6px;
+  }
+
+  .fleet-row > :nth-child(3),
+  .fleet-row > :nth-child(4) {
+    grid-column: span 2;
+  }
+
+  #mobileTabBar {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+    background: #151a21;
+    border-top: 1px solid #1f2630;
+    position: sticky;
+    bottom: 0;
+    z-index: 5;
+  }
+
+  input[type="range"],
+  select,
+  button,
+  input[type="number"],
+  textarea {
+    font-size: 16px;
+  }
+}
+
+@media (max-width: 600px) {
+  h1.title {
+    font-size: 16px;
+  }
+
+  .mobile-tab {
+    font-size: 13px;
+  }
+}


### PR DESCRIPTION
## Summary
- restructure the app shell to split the game, controls, and insight panels and expose them through a mobile tab bar
- add responsive tab switching logic that hides non-active panels and resizes the canvas when returning to the game view
- refresh the simulator styling with mobile-friendly spacing, typography, and navigation affordances

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf7312e73483269411dd27be32f1e7