### PR TITLE
Add mobile-friendly tab navigation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,104 +8,118 @@ const app = document.querySelector<HTMLDivElement>('#app')!
 app.innerHTML = `
   <div id="gameParent"></div>
   <div id="sidebar">
-    <h1 class="title">Elevator Simulator</h1>
-    <div class="section">
-      <div class="grid-two">
-        <div>
-          <label for="floors">Floors</label>
-          <input id="floors" type="number" min="2" max="50" value="10"/>
-        </div>
-        <div>
-          <label for="elevators">Elevators</label>
-          <input id="elevators" type="number" min="1" max="16" value="3"/>
-        </div>
-      </div>
-      <div class="row">
-        <label for="spawnRate">Spawn Rate (ppl/min)</label>
-        <input id="spawnRate" type="range" min="0" max="200" value="40"/>
-      </div>
-      <div class="row">
-        <label></label>
-        <div class="small" id="spawnRateLabel">40 ppl/min</div>
-      </div>
-      <div class="row">
-        <label for="algorithm">Algorithm</label>
-        <select id="algorithm">
-          <option value="nearest">Nearest Car</option>
-          <option value="exclusiveNearest">Single Responder (Nearest)</option>
-          <option value="collective">Collective (Simple)</option>
-          <option value="zoned">Zoned (Sectorized)</option>
-          <option value="idleLobby">Idle To Lobby</option>
-          <option value="custom">Custom (Editor)</option>
-        </select>
-      </div>
-      <div class="row">
-        <button id="apply" class="primary">Apply & Restart</button>
-        <button id="pause">Pause</button>
+    <div class="sidebar-header">
+      <h1 class="title">Elevator Simulator</h1>
+      <div class="tab-bar" role="tablist" aria-label="Simulator panels">
+        <button class="tab-button active" data-screen="run" role="tab" aria-selected="true" aria-controls="screen-run" id="tab-run" tabindex="0">Run</button>
+        <button class="tab-button" data-screen="crowd" role="tab" aria-selected="false" aria-controls="screen-crowd" id="tab-crowd" tabindex="-1">Crowd</button>
+        <button class="tab-button" data-screen="stats" role="tab" aria-selected="false" aria-controls="screen-stats" id="tab-stats" tabindex="-1">Status</button>
       </div>
     </div>
 
-    <div class="section">
-      <h1 class="title">Crowd Model</h1>
-      <div class="row">
-        <label for="groundBias">Ground Floor Bias</label>
-        <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
-      </div>
-      <div class="row"><label></label><div id="groundBiasLabel" class="small">x3.0</div></div>
-      <div class="row">
-        <label for="toLobbyPct">To Lobby Preference</label>
-        <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
-      </div>
-      <div class="row"><label></label><div id="toLobbyPctLabel" class="small">70%</div></div>
-    </div>
-
-    <div class="section">
-      <h1 class="title">Manual Call</h1>
-      <div class="grid-two">
-        <div>
-          <label for="manualFloor">Floor</label>
-          <input id="manualFloor" type="number" min="0" max="49" value="0"/>
+    <div class="screen active" data-screen="run" id="screen-run" role="tabpanel" aria-labelledby="tab-run">
+      <div class="section">
+        <div class="grid-two">
+          <div>
+            <label for="floors">Floors</label>
+            <input id="floors" type="number" min="2" max="50" value="10"/>
+          </div>
+          <div>
+            <label for="elevators">Elevators</label>
+            <input id="elevators" type="number" min="1" max="16" value="3"/>
+          </div>
         </div>
-        <div>
-          <label for="manualDir">Direction</label>
-          <select id="manualDir">
-            <option value="up">Up</option>
-            <option value="down">Down</option>
+        <div class="row">
+          <label for="spawnRate">Spawn Rate (ppl/min)</label>
+          <input id="spawnRate" type="range" min="0" max="200" value="40"/>
+        </div>
+        <div class="row">
+          <label></label>
+          <div class="small" id="spawnRateLabel">40 ppl/min</div>
+        </div>
+        <div class="row">
+          <label for="algorithm">Algorithm</label>
+          <select id="algorithm">
+            <option value="nearest">Nearest Car</option>
+            <option value="exclusiveNearest">Single Responder (Nearest)</option>
+            <option value="collective">Collective (Simple)</option>
+            <option value="zoned">Zoned (Sectorized)</option>
+            <option value="idleLobby">Idle To Lobby</option>
+            <option value="custom">Custom (Editor)</option>
           </select>
         </div>
+        <div class="row">
+          <button id="apply" class="primary">Apply & Restart</button>
+          <button id="pause">Pause</button>
+        </div>
       </div>
-      <div class="row">
-        <button id="manualCall" class="primary">Call Elevator</button>
+
+      <div class="section">
+        <h1 class="title">Manual Call</h1>
+        <div class="grid-two">
+          <div>
+            <label for="manualFloor">Floor</label>
+            <input id="manualFloor" type="number" min="0" max="49" value="0"/>
+          </div>
+          <div>
+            <label for="manualDir">Direction</label>
+            <select id="manualDir">
+              <option value="up">Up</option>
+              <option value="down">Down</option>
+            </select>
+          </div>
+        </div>
+        <div class="row">
+          <button id="manualCall" class="primary">Call Elevator</button>
+        </div>
+      </div>
+
+      <div class="section" id="customEditorSection" style="display:none;">
+        <div class="small" style="margin-bottom:6px;">
+          Provide a JS function named <code>decide</code> taking a state object and returning decisions.
+        </div>
+        <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
+        <div class="row">
+          <button id="loadCustom" class="primary">Load Custom Algorithm</button>
+        </div>
       </div>
     </div>
 
-    <div class="section" id="customEditorSection" style="display:none;">
-      <div class="small" style="margin-bottom:6px;">
-        Provide a JS function named <code>decide</code> taking a state object and returning decisions.
-      </div>
-      <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
-      <div class="row">
-        <button id="loadCustom" class="primary">Load Custom Algorithm</button>
-      </div>
-    </div>
-
-    <div class="section">
-      <div class="stats">
-        <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
-        <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
-        <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
-        <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
+    <div class="screen" data-screen="crowd" id="screen-crowd" role="tabpanel" aria-labelledby="tab-crowd">
+      <div class="section">
+        <h1 class="title">Crowd Model</h1>
+        <div class="row">
+          <label for="groundBias">Ground Floor Bias</label>
+          <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
+        </div>
+        <div class="row"><label></label><div id="groundBiasLabel" class="small">x3.0</div></div>
+        <div class="row">
+          <label for="toLobbyPct">To Lobby Preference</label>
+          <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
+        </div>
+        <div class="row"><label></label><div id="toLobbyPctLabel" class="small">70%</div></div>
       </div>
     </div>
 
-    <div class="section">
-      <h1 class="title">Fleet</h1>
-      <div id="fleetList" class="fleet-list"></div>
-    </div>
+    <div class="screen" data-screen="stats" id="screen-stats" role="tabpanel" aria-labelledby="tab-stats">
+      <div class="section">
+        <div class="stats">
+          <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
+          <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
+          <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
+          <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
+        </div>
+      </div>
 
-    <div class="section">
-      <h1 class="title">Floor Calls</h1>
-      <div id="floorCalls" class="floor-calls"></div>
+      <div class="section">
+        <h1 class="title">Fleet</h1>
+        <div id="fleetList" class="fleet-list"></div>
+      </div>
+
+      <div class="section">
+        <h1 class="title">Floor Calls</h1>
+        <div id="floorCalls" class="floor-calls"></div>
+      </div>
     </div>
   </div>
 `

--- a/src/style.css
+++ b/src/style.css
@@ -1,98 +1,53 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #e7ecf3;
+  background-color: #0f1216;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background: #0f1216;
+  color: #e7ecf3;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: #8cb4ff;
+  text-decoration: none;
 }
 
-#app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vanilla:hover {
-  filter: drop-shadow(0 0 2em #3178c6aa);
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+a:hover {
+  color: #bad0ff;
 }
 
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
+  border: 1px solid #2a2f3a;
+  padding: 0.55em 1em;
+  font-size: 0.95rem;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #11151b;
+  color: #e7ecf3;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button:hover {
+  background-color: #16202c;
+}
+
+button:focus,
+button:focus-visible {
+  outline: 2px solid #386796;
+  outline-offset: 2px;
 }
 
 /* App layout overrides for the simulator */
@@ -106,6 +61,7 @@ html, body, #app { height: 100%; }
   height: 100%;
   max-width: none;
   padding: 0;
+  width: 100%;
 }
 
 #gameParent {
@@ -116,11 +72,50 @@ html, body, #app { height: 100%; }
 }
 
 #sidebar {
+  display: flex;
+  flex-direction: column;
   background: #151a21;
   border-left: 1px solid #1f2630;
-  padding: 14px 14px 100px;
-  overflow: auto;
+  padding: 18px 20px 96px;
+  overflow-y: auto;
   text-align: left;
+  gap: 24px;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+.sidebar-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 4px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #1f2630;
+}
+
+.tab-bar {
+  display: none;
+  gap: 8px;
+  background: #10141b;
+  border: 1px solid #1f2630;
+  border-radius: 999px;
+  padding: 4px;
+}
+
+.tab-button {
+  border-radius: 999px;
+  border-color: #1f2630;
+  background: #11151b;
+  color: #a5b0bf;
+  flex: 1;
+  padding: 0.45em 0.8em;
+  font-size: 0.9rem;
+}
+
+.tab-button.active {
+  background: #173047;
+  border-color: #21435e;
+  color: #e7ecf3;
 }
 
 h1.title {
@@ -128,19 +123,43 @@ h1.title {
   margin: 0 0 12px;
 }
 
-.section { margin-bottom: 16px; }
+.screen {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.screen:not(.active) {
+  transition: none;
+}
+
+.section { margin: 0; }
 
 .row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
   margin: 8px 0;
 }
 
-label { color: #a5b0bf; font-size: 12px; }
+label {
+  color: #a5b0bf;
+  font-size: 12px;
+}
 
-input[type="range"], select, button, input[type="number"], textarea {
+.row label {
+  flex: 0 0 140px;
+}
+
+.row > *:not(label) {
+  flex: 1;
+}
+
+.row button {
+  flex: 1;
+}
+
+input[type="range"], select, input[type="number"], textarea {
   width: 100%;
   background: #11151b;
   color: #e7ecf3;
@@ -151,9 +170,15 @@ input[type="range"], select, button, input[type="number"], textarea {
 }
 
 input[type="range"] { padding: 0; }
-button { cursor: pointer; }
-button.primary { background: #173047; border-color: #21435e; }
-button.primary:hover { background: #183650; }
+button.primary {
+  background: #173047;
+  border-color: #21435e;
+  color: #e7ecf3;
+}
+
+button.primary:hover {
+  background: #1c3c59;
+}
 
 .grid-two {
   display: grid;
@@ -179,6 +204,7 @@ button.primary:hover { background: #183650; }
 .ok { color: #58d68d; }
 .warn { color: #ffd166; }
 .small { font-size: 12px; color: #a5b0bf; }
+#sidebar .row .small { text-align: right; }
 
 .code-editor {
   width: 100%;
@@ -221,3 +247,108 @@ button.primary:hover { background: #183650; }
 .badge { border:1px solid #2a2f3a; border-radius:999px; padding:2px 8px; font-size:12px; }
 .badge.up { color:#58d68d; }
 .badge.down { color:#ff6b6b; }
+
+@media (max-width: 900px) {
+  #app {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(280px, 55vh) minmax(0, 1fr);
+    height: auto;
+  }
+
+  #gameParent {
+    min-height: 280px;
+  }
+
+  #sidebar {
+    border-left: none;
+    border-top: 1px solid #1f2630;
+    padding: 16px 16px 80px;
+    gap: 20px;
+  }
+
+  .sidebar-header {
+    position: sticky;
+    top: 0;
+    background: #151a21;
+    padding-top: 8px;
+    padding-bottom: 16px;
+    margin-bottom: 0;
+    z-index: 2;
+  }
+
+  .tab-bar {
+    display: flex;
+  }
+
+  .tab-button {
+    font-size: 1rem;
+    padding: 0.55em 0.9em;
+  }
+
+  .screen {
+    display: none;
+  }
+
+  .screen.active {
+    display: flex;
+  }
+
+  .row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .row label {
+    flex: none;
+  }
+
+  .row > *:not(label) {
+    width: 100%;
+  }
+
+  .row label:empty {
+    display: none;
+  }
+
+  .row .small {
+    text-align: left;
+  }
+
+  .grid-two {
+    grid-template-columns: 1fr;
+  }
+
+  .stats {
+    grid-template-columns: 1fr;
+  }
+
+  .fleet-row {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .call-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+}
+
+@media (max-width: 600px) {
+  #gameParent {
+    min-height: 240px;
+  }
+
+  .tab-bar {
+    padding: 6px;
+  }
+
+  button {
+    font-size: 1rem;
+  }
+
+  #sidebar {
+    padding: 14px 14px 72px;
+  }
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -25,6 +25,56 @@ export function setupUI(game: Phaser.Game) {
   const manualDir = getEl<HTMLSelectElement>('manualDir')
   const manualCall = getEl<HTMLButtonElement>('manualCall')
 
+  const tabButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('.tab-button'))
+  const screens = Array.from(document.querySelectorAll<HTMLDivElement>('.screen'))
+  if (tabButtons.length && screens.length) {
+    let activeScreen = tabButtons.find(btn => btn.classList.contains('active'))?.dataset.screen ?? tabButtons[0]?.dataset.screen ?? ''
+    const tabMedia = window.matchMedia('(max-width: 900px)')
+
+    const applyTabState = () => {
+      if (!activeScreen) return
+      screens.forEach(screen => {
+        const isActive = screen.dataset.screen === activeScreen
+        screen.classList.toggle('active', isActive)
+        if (tabMedia.matches) {
+          screen.setAttribute('aria-hidden', isActive ? 'false' : 'true')
+        } else {
+          screen.setAttribute('aria-hidden', 'false')
+        }
+      })
+
+      tabButtons.forEach(btn => {
+        const isActive = btn.dataset.screen === activeScreen
+        btn.classList.toggle('active', isActive)
+        btn.setAttribute('aria-selected', isActive ? 'true' : 'false')
+        if (tabMedia.matches) {
+          btn.setAttribute('tabindex', isActive ? '0' : '-1')
+        } else {
+          btn.setAttribute('tabindex', '0')
+        }
+      })
+    }
+
+    const setActiveScreen = (target: string) => {
+      if (!target || target === activeScreen) return
+      activeScreen = target
+      applyTabState()
+    }
+
+    tabButtons.forEach(btn => {
+      btn.addEventListener('click', () => setActiveScreen(btn.dataset.screen ?? ''))
+    })
+
+    const handleTabMediaChange = () => applyTabState()
+    if (typeof tabMedia.addEventListener === 'function') {
+      tabMedia.addEventListener('change', handleTabMediaChange)
+    } else {
+      tabMedia.addListener(handleTabMediaChange)
+    }
+
+    applyTabState()
+  }
+
   const defaultCustom = `// Example custom algorithm
 // state: { time, elevators:[{ position, direction, capacity, passengers:[{dest}] }], floors, calls:{up:[],down:[]} }
 function decide(state){


### PR DESCRIPTION
## Summary
- reorganized the sidebar markup into Run, Crowd, and Status screens with a tab bar so the simulator is easier to use on phones
- implemented tab switching behavior that keeps accessibility attributes in sync with viewport changes
- refreshed global styling and responsive rules to optimize forms, stats, and lists for smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf7312e73483269411dd27be32f1e7