### PR TITLE
Add mobile-friendly tabbed sidebar layout

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,104 +8,121 @@ const app = document.querySelector<HTMLDivElement>('#app')!
 app.innerHTML = `
   <div id="gameParent"></div>
   <div id="sidebar">
-    <h1 class="title">Elevator Simulator</h1>
-    <div class="section">
-      <div class="grid-two">
-        <div>
-          <label for="floors">Floors</label>
-          <input id="floors" type="number" min="2" max="50" value="10"/>
-        </div>
-        <div>
-          <label for="elevators">Elevators</label>
-          <input id="elevators" type="number" min="1" max="16" value="3"/>
-        </div>
-      </div>
-      <div class="row">
-        <label for="spawnRate">Spawn Rate (ppl/min)</label>
-        <input id="spawnRate" type="range" min="0" max="200" value="40"/>
-      </div>
-      <div class="row">
-        <label></label>
-        <div class="small" id="spawnRateLabel">40 ppl/min</div>
-      </div>
-      <div class="row">
-        <label for="algorithm">Algorithm</label>
-        <select id="algorithm">
-          <option value="nearest">Nearest Car</option>
-          <option value="exclusiveNearest">Single Responder (Nearest)</option>
-          <option value="collective">Collective (Simple)</option>
-          <option value="zoned">Zoned (Sectorized)</option>
-          <option value="idleLobby">Idle To Lobby</option>
-          <option value="custom">Custom (Editor)</option>
-        </select>
-      </div>
-      <div class="row">
-        <button id="apply" class="primary">Apply & Restart</button>
-        <button id="pause">Pause</button>
+    <div class="sidebar-header">
+      <h1 class="title sidebar-title">Elevator Simulator</h1>
+      <div class="tab-bar" role="tablist" aria-label="Sidebar panels">
+        <button type="button" class="tab active" data-tab-button="controls" aria-selected="true" tabindex="0">Controls</button>
+        <button type="button" class="tab" data-tab-button="stats" aria-selected="false" tabindex="-1">Stats</button>
+        <button type="button" class="tab" data-tab-button="custom" aria-selected="false" tabindex="-1">Custom</button>
       </div>
     </div>
-
-    <div class="section">
-      <h1 class="title">Crowd Model</h1>
-      <div class="row">
-        <label for="groundBias">Ground Floor Bias</label>
-        <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
-      </div>
-      <div class="row"><label></label><div id="groundBiasLabel" class="small">x3.0</div></div>
-      <div class="row">
-        <label for="toLobbyPct">To Lobby Preference</label>
-        <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
-      </div>
-      <div class="row"><label></label><div id="toLobbyPctLabel" class="small">70%</div></div>
-    </div>
-
-    <div class="section">
-      <h1 class="title">Manual Call</h1>
-      <div class="grid-two">
-        <div>
-          <label for="manualFloor">Floor</label>
-          <input id="manualFloor" type="number" min="0" max="49" value="0"/>
+    <div class="sidebar-body">
+      <div class="section" data-tab-section="controls">
+        <h2 class="title">Simulation</h2>
+        <div class="grid-two">
+          <div>
+            <label for="floors">Floors</label>
+            <input id="floors" type="number" min="2" max="50" value="10"/>
+          </div>
+          <div>
+            <label for="elevators">Elevators</label>
+            <input id="elevators" type="number" min="1" max="16" value="3"/>
+          </div>
         </div>
-        <div>
-          <label for="manualDir">Direction</label>
-          <select id="manualDir">
-            <option value="up">Up</option>
-            <option value="down">Down</option>
+        <div class="row">
+          <label for="spawnRate">Spawn Rate (ppl/min)</label>
+          <input id="spawnRate" type="range" min="0" max="200" value="40"/>
+        </div>
+        <div class="row">
+          <label></label>
+          <div class="small" id="spawnRateLabel">40 ppl/min</div>
+        </div>
+        <div class="row">
+          <label for="algorithm">Algorithm</label>
+          <select id="algorithm">
+            <option value="nearest">Nearest Car</option>
+            <option value="exclusiveNearest">Single Responder (Nearest)</option>
+            <option value="collective">Collective (Simple)</option>
+            <option value="zoned">Zoned (Sectorized)</option>
+            <option value="idleLobby">Idle To Lobby</option>
+            <option value="custom">Custom (Editor)</option>
           </select>
         </div>
+        <div class="row button-row">
+          <button id="apply" class="primary" type="button">Apply & Restart</button>
+          <button id="pause" type="button">Pause</button>
+        </div>
       </div>
-      <div class="row">
-        <button id="manualCall" class="primary">Call Elevator</button>
-      </div>
-    </div>
 
-    <div class="section" id="customEditorSection" style="display:none;">
-      <div class="small" style="margin-bottom:6px;">
-        Provide a JS function named <code>decide</code> taking a state object and returning decisions.
+      <div class="section" data-tab-section="controls">
+        <h2 class="title">Crowd Model</h2>
+        <div class="row">
+          <label for="groundBias">Ground Floor Bias</label>
+          <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
+        </div>
+        <div class="row"><label></label><div id="groundBiasLabel" class="small">x3.0</div></div>
+        <div class="row">
+          <label for="toLobbyPct">To Lobby Preference</label>
+          <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
+        </div>
+        <div class="row"><label></label><div id="toLobbyPctLabel" class="small">70%</div></div>
       </div>
-      <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
-      <div class="row">
-        <button id="loadCustom" class="primary">Load Custom Algorithm</button>
+
+      <div class="section" data-tab-section="controls">
+        <h2 class="title">Manual Call</h2>
+        <div class="grid-two">
+          <div>
+            <label for="manualFloor">Floor</label>
+            <input id="manualFloor" type="number" min="0" max="49" value="0"/>
+          </div>
+          <div>
+            <label for="manualDir">Direction</label>
+            <select id="manualDir">
+              <option value="up">Up</option>
+              <option value="down">Down</option>
+            </select>
+          </div>
+        </div>
+        <div class="row">
+          <button id="manualCall" class="primary" type="button">Call Elevator</button>
+        </div>
       </div>
-    </div>
 
-    <div class="section">
-      <div class="stats">
-        <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
-        <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
-        <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
-        <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
+      <div class="section" data-tab-section="custom">
+        <h2 class="title">Custom Algorithm</h2>
+        <div id="customPlaceholder" class="custom-placeholder small">
+          Select "Custom (Editor)" from the algorithm list to enable the editor.
+        </div>
+        <div id="customEditorSection" class="custom-editor">
+          <div class="small" style="margin-bottom:6px;">
+            Provide a JS function named <code>decide</code> taking a state object and returning decisions.
+          </div>
+          <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
+          <div class="row">
+            <button id="loadCustom" class="primary" type="button">Load Custom Algorithm</button>
+          </div>
+        </div>
       </div>
-    </div>
 
-    <div class="section">
-      <h1 class="title">Fleet</h1>
-      <div id="fleetList" class="fleet-list"></div>
-    </div>
+      <div class="section" data-tab-section="stats">
+        <h2 class="title">Performance</h2>
+        <div class="stats">
+          <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
+          <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
+          <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
+          <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
+        </div>
+      </div>
 
-    <div class="section">
-      <h1 class="title">Floor Calls</h1>
-      <div id="floorCalls" class="floor-calls"></div>
+      <div class="section" data-tab-section="stats">
+        <h2 class="title">Fleet</h2>
+        <div id="fleetList" class="fleet-list"></div>
+      </div>
+
+      <div class="section" data-tab-section="stats">
+        <h2 class="title">Floor Calls</h2>
+        <div id="floorCalls" class="floor-calls"></div>
+      </div>
     </div>
   </div>
 `

--- a/src/style.css
+++ b/src/style.css
@@ -24,10 +24,11 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background: #0f1216;
+  color: #e7ecf3;
+  display: block;
 }
 
 h1 {
@@ -36,10 +37,10 @@ h1 {
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  max-width: none;
+  margin: 0;
+  padding: 0;
+  text-align: left;
 }
 
 .logo {
@@ -82,6 +83,31 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+button.tab {
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: #a5b0bf;
+  padding: 8px 0;
+  min-height: 36px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.tab-bar .tab:hover {
+  border: none;
+  background: #1f2630;
+}
+
+.tab-bar .tab.active {
+  background: #173047;
+  color: #e7ecf3;
+}
+
+.tab-bar .tab:focus-visible {
+  outline: 2px solid #366ea3;
+  outline-offset: 2px;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
@@ -118,17 +144,77 @@ html, body, #app { height: 100%; }
 #sidebar {
   background: #151a21;
   border-left: 1px solid #1f2630;
-  padding: 14px 14px 100px;
-  overflow: auto;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   text-align: left;
 }
 
-h1.title {
-  font-size: 18px;
-  margin: 0 0 12px;
+.sidebar-header {
+  flex-shrink: 0;
+  margin-bottom: 16px;
 }
 
-.section { margin-bottom: 16px; }
+.sidebar-title {
+  margin: 0;
+  font-size: 20px;
+  text-align: center;
+}
+
+.tab-bar {
+  display: none;
+  align-items: center;
+  gap: 4px;
+  margin-top: 12px;
+  padding: 4px;
+  border: 1px solid #1f2630;
+  border-radius: 999px;
+  background: #10141b;
+}
+
+.sidebar-body {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 6px;
+  padding-bottom: 48px;
+}
+
+.title {
+  font-size: 18px;
+  margin: 0 0 12px;
+  font-weight: 600;
+}
+
+.section { margin-bottom: 20px; }
+
+.row.button-row {
+  align-items: stretch;
+}
+
+.row.button-row button {
+  flex: 1;
+}
+
+.custom-editor {
+  display: none;
+}
+
+.custom-editor.is-visible {
+  display: block;
+}
+
+.custom-placeholder {
+  padding: 10px 12px;
+  border: 1px dashed #2a2f3a;
+  border-radius: 6px;
+  background: #11151b;
+  margin-bottom: 12px;
+}
+
+.is-hidden {
+  display: none !important;
+}
 
 .row {
   display: flex;
@@ -140,7 +226,7 @@ h1.title {
 
 label { color: #a5b0bf; font-size: 12px; }
 
-input[type="range"], select, button, input[type="number"], textarea {
+input[type="range"], select, button:not(.tab), input[type="number"], textarea {
   width: 100%;
   background: #11151b;
   color: #e7ecf3;
@@ -151,6 +237,7 @@ input[type="range"], select, button, input[type="number"], textarea {
 }
 
 input[type="range"] { padding: 0; }
+select, button:not(.tab), input[type="number"], textarea { min-height: 38px; }
 button { cursor: pointer; }
 button.primary { background: #173047; border-color: #21435e; }
 button.primary:hover { background: #183650; }
@@ -221,3 +308,83 @@ button.primary:hover { background: #183650; }
 .badge { border:1px solid #2a2f3a; border-radius:999px; padding:2px 8px; font-size:12px; }
 .badge.up { color:#58d68d; }
 .badge.down { color:#ff6b6b; }
+
+@media (max-width: 960px) {
+  #app {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(320px, 55vh) auto;
+  }
+
+  #sidebar {
+    border-left: none;
+    border-top: 1px solid #1f2630;
+    padding: 16px 12px 24px;
+  }
+
+  .sidebar-header {
+    position: sticky;
+    top: 0;
+    background: #151a21;
+    padding-bottom: 12px;
+    margin-bottom: 16px;
+    z-index: 2;
+  }
+
+  .tab-bar {
+    display: flex;
+  }
+
+  .sidebar-body {
+    padding-right: 0;
+  }
+
+  .section[data-tab-section] {
+    display: none;
+  }
+
+  .section[data-tab-section].tab-active {
+    display: block;
+  }
+
+  .row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .row label {
+    width: 100%;
+  }
+
+  .row .small {
+    margin-top: 2px;
+  }
+
+  .grid-two {
+    grid-template-columns: 1fr;
+  }
+
+  .stats {
+    grid-template-columns: 1fr;
+  }
+
+  .fleet-row {
+    grid-template-columns: 38px 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .fleet-row > div:nth-child(3),
+  .fleet-row > div:nth-child(4) {
+    grid-column: 1 / -1;
+    text-align: left;
+  }
+
+  #gameParent {
+    min-height: 320px;
+  }
+}
+
+@media (min-width: 961px) {
+  .sidebar-title {
+    text-align: left;
+  }
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -17,8 +17,37 @@ export function setupUI(game: Phaser.Game) {
   const toLobbyPctLabel = getEl<HTMLDivElement>('toLobbyPctLabel')
 
   const customSection = getEl<HTMLDivElement>('customEditorSection')
+  const customPlaceholder = getEl<HTMLDivElement>('customPlaceholder')
   const customCode = getEl<HTMLTextAreaElement>('customCode')
   const loadCustom = getEl<HTMLButtonElement>('loadCustom')
+
+  const tabButtons = Array.from(document.querySelectorAll<HTMLButtonElement>('[data-tab-button]'))
+  const tabSections = Array.from(document.querySelectorAll<HTMLElement>('[data-tab-section]'))
+  const mobileQuery = window.matchMedia('(max-width: 960px)')
+
+  function setActiveTab(tab: string) {
+    tabButtons.forEach(btn => {
+      const target = btn.dataset.tabButton
+      const isActive = target === tab
+      btn.classList.toggle('active', isActive)
+      btn.setAttribute('aria-selected', isActive ? 'true' : 'false')
+      btn.setAttribute('tabindex', isActive ? '0' : '-1')
+    })
+
+    tabSections.forEach(section => {
+      const target = section.dataset.tabSection
+      section.classList.toggle('tab-active', target === tab)
+    })
+  }
+
+  tabButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = btn.dataset.tabButton
+      if (target) setActiveTab(target)
+    })
+  })
+
+  setActiveTab('controls')
 
   // Manual call
   const manualFloor = getEl<HTMLInputElement>('manualFloor')
@@ -59,9 +88,18 @@ function decide(state){
   toLobbyPct.addEventListener('input', updateLobbyLabel)
   updateLobbyLabel()
 
-  algorithmSelect.addEventListener('change', () => {
-    customSection.style.display = algorithmSelect.value === 'custom' ? 'block' : 'none'
-  })
+  function updateCustomVisibility() {
+    const isCustom = algorithmSelect.value === 'custom'
+    customSection.classList.toggle('is-visible', isCustom)
+    customPlaceholder.classList.toggle('is-hidden', isCustom)
+
+    if (isCustom && mobileQuery.matches) {
+      setActiveTab('custom')
+    }
+  }
+
+  algorithmSelect.addEventListener('change', updateCustomVisibility)
+  updateCustomVisibility()
 
   applyBtn.addEventListener('click', () => {
     const floors = clamp(parseInt(floorsInput.value || '10', 10), 2, 50)


### PR DESCRIPTION
## Summary
- restructure the sidebar markup into tabbed sections with mobile-friendly navigation and grouped content
- add UI logic for tab selection, responsive custom editor visibility, and mobile-aware behavior
- refresh styling for the sidebar and form controls to support touch-friendly layouts and responsive sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf7312e73483269411dd27be32f1e7