### PR TITLE
Add hall call claiming and visualize next destination

### DIFF
--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -29,6 +29,7 @@ export interface AlgorithmState {
   elevators: ElevatorState[]
   floors: number
   calls: { up: number[]; down: number[] }
+  hallClaims: (number | null)[]
 }
 
 export interface AlgorithmDecision {


### PR DESCRIPTION
## Summary
- add hall call claim tracking to algorithm state so only one elevator responds to a hall call at a time
- update the simulation loop to maintain hall call ownership and drop duplicate targets from other cars
- highlight the next destination target in green while leaving other queued stops red

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff63bf504832694d2ba586a7df9bc