### PR TITLE
Implement hall call claiming and highlight next destinations

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -174,9 +174,14 @@ export class GameScene extends Phaser.Scene {
       this.gfx.fillRect(x + 2, barY, Math.max(0, (shaftWidth - 4) * capPct), barH)
 
       // targets markers
-      this.gfx.lineStyle(1, 0xff6b6b, 1)
-      for (const t of elev.targets) {
+      const sortedTargets = [...elev.targets].sort((a, b) => a - b)
+      const nextStop = this.sim.getNextStopFor(elev.id)
+      for (const t of sortedTargets) {
         const ty = buildingBottom - t * this.floorHeight - 2
+        const isNext = nextStop === t
+        const color = isNext ? 0x58d68d : 0xff6b6b
+        const thickness = isNext ? 2 : 1
+        this.gfx.lineStyle(thickness, color, 1)
         this.gfx.beginPath(); this.gfx.moveTo(x + 2, ty); this.gfx.lineTo(x + shaftWidth - 2, ty); this.gfx.strokePath()
       }
     }


### PR DESCRIPTION
## Summary
- add per-floor hall call claiming so only one elevator responds to each request at a time
- release or transfer claims as stops are served and expose a helper to query the next destination
- highlight an elevator's imminent stop in green while leaving future stops red in the scene rendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff63bf504832694d2ba586a7df9bc