### PR TITLE
Implement hall call claiming and highlight next stops

### DIFF
--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -174,8 +174,10 @@ export class GameScene extends Phaser.Scene {
       this.gfx.fillRect(x + 2, barY, Math.max(0, (shaftWidth - 4) * capPct), barH)
 
       // targets markers
-      this.gfx.lineStyle(1, 0xff6b6b, 1)
+      const nextStop = this.sim.getNextStop(i)
       for (const t of elev.targets) {
+        const isNext = nextStop !== null && t === nextStop
+        this.gfx.lineStyle(1, isNext ? 0x58d68d : 0xff6b6b, 1)
         const ty = buildingBottom - t * this.floorHeight - 2
         this.gfx.beginPath(); this.gfx.moveTo(x + 2, ty); this.gfx.lineTo(x + shaftWidth - 2, ty); this.gfx.strokePath()
       }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -22,6 +22,8 @@ export interface ElevatorState {
 export interface FloorState {
   upQueue: Passenger[]
   downQueue: Passenger[]
+  claimedUpBy: number | null
+  claimedDownBy: number | null
 }
 
 export interface AlgorithmState {


### PR DESCRIPTION
## Summary
- track per-direction hall call claims and filter algorithm dispatching so a single elevator services each request
- release claims when calls are cleared and expose `getNextStop` to surface an elevator's next destination
- color target markers green for the next stop in the visualizer for quick confirmation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cff63bf504832694d2ba586a7df9bc