### PR TITLE
Add nearest non-busy car dispatch algorithm

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ app.innerHTML = `
           <label for="algorithm">Algorithm</label>
           <select id="algorithm">
             <option value="nearest">Nearest Car</option>
+            <option value="nearestNonBusy">Nearest Non-Busy Car</option>
             <option value="exclusiveNearest">Single Responder (Nearest)</option>
             <option value="collective">Collective (Simple)</option>
             <option value="zoned">Zoned (Sectorized)</option>


### PR DESCRIPTION
## Summary
- add a dispatch algorithm that prefers the nearest elevator without any pending destinations and falls back to the classic nearest car logic when all cabs are busy
- expose the new "Nearest Non-Busy Car" example in the algorithm selector

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0068a512483268b2d8d8979d96555