### PR TITLE
Add multi-view layout and interaction controls

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,122 +6,140 @@ import { setupUI } from './ui'
 const app = document.querySelector<HTMLDivElement>('#app')!
 
 app.innerHTML = `
-  <div id="gameParent"></div>
-  <div id="sidebar">
-    <div class="sidebar-header">
-      <h1 class="title">Elevator Simulator</h1>
-      <div class="tab-bar" role="tablist" aria-label="Simulator panels">
-        <button class="tab-button active" data-screen="run" role="tab" aria-selected="true" aria-controls="screen-run" id="tab-run" tabindex="0">Run</button>
-        <button class="tab-button" data-screen="crowd" role="tab" aria-selected="false" aria-controls="screen-crowd" id="tab-crowd" tabindex="-1">Crowd</button>
-        <button class="tab-button" data-screen="stats" role="tab" aria-selected="false" aria-controls="screen-stats" id="tab-stats" tabindex="-1">Status</button>
+  <div class="app-shell" data-active-view="simulation">
+    <header class="app-header">
+      <div class="brand">
+        <span class="brand-title">Elevator Simulator</span>
+        <span class="brand-subtitle">Operations Lab</span>
       </div>
-    </div>
-
-    <div class="screen active" data-screen="run" id="screen-run" role="tabpanel" aria-labelledby="tab-run">
-      <div class="section">
-        <div class="grid-two">
-          <div>
-            <label for="floors">Floors</label>
-            <input id="floors" type="number" min="2" max="50" value="10"/>
+      <nav class="nav-bar" role="tablist" aria-label="Simulator views">
+        <button class="nav-link active" data-view="simulation" role="tab" aria-selected="true" aria-controls="view-simulation" id="tab-simulation" tabindex="0">Simulation</button>
+        <button class="nav-link" data-view="controls" role="tab" aria-selected="false" aria-controls="view-controls" id="tab-controls" tabindex="-1">Operations</button>
+        <button class="nav-link" data-view="crowd" role="tab" aria-selected="false" aria-controls="view-crowd" id="tab-crowd" tabindex="-1">Crowd</button>
+        <button class="nav-link" data-view="stats" role="tab" aria-selected="false" aria-controls="view-stats" id="tab-stats" tabindex="-1">Status</button>
+      </nav>
+    </header>
+    <main id="view-root">
+      <section id="view-simulation" class="simulation-layer" role="tabpanel" data-view="simulation" aria-labelledby="tab-simulation" aria-hidden="false">
+        <div id="gameParent"></div>
+      </section>
+      <section id="view-controls" class="view-panel" data-view="controls" role="tabpanel" aria-labelledby="tab-controls" aria-hidden="true" tabindex="-1">
+        <div class="panel-scroll">
+          <div class="panel-card">
+            <h2 class="title">Run Configuration</h2>
+            <div class="grid-two">
+              <div>
+                <label for="floors">Floors</label>
+                <input id="floors" type="number" min="2" max="50" value="10"/>
+              </div>
+              <div>
+                <label for="elevators">Elevators</label>
+                <input id="elevators" type="number" min="1" max="16" value="3"/>
+              </div>
+            </div>
+            <div class="row">
+              <label for="spawnRate">Spawn Rate (ppl/min)</label>
+              <input id="spawnRate" type="range" min="0" max="200" value="40"/>
+            </div>
+            <div class="row">
+              <label></label>
+              <div class="small" id="spawnRateLabel">40 ppl/min</div>
+            </div>
+            <div class="row">
+              <label for="algorithm">Algorithm</label>
+              <select id="algorithm">
+                <option value="nearest">Nearest Car</option>
+                <option value="nearestNonBusy">Nearest Non-Busy Car</option>
+                <option value="exclusiveNearest">Single Responder (Nearest)</option>
+                <option value="collective">Collective (Simple)</option>
+                <option value="zoned">Zoned (Sectorized)</option>
+                <option value="idleLobby">Idle To Lobby</option>
+                <option value="custom">Custom (Editor)</option>
+              </select>
+            </div>
+            <div class="row button-row">
+              <button id="apply" class="primary">Apply &amp; Restart</button>
+              <button id="pause">Pause</button>
+            </div>
           </div>
-          <div>
-            <label for="elevators">Elevators</label>
-            <input id="elevators" type="number" min="1" max="16" value="3"/>
+
+          <div class="panel-card">
+            <h2 class="title">Manual Call</h2>
+            <div class="grid-two">
+              <div>
+                <label for="manualFloor">Floor</label>
+                <input id="manualFloor" type="number" min="0" max="49" value="0"/>
+              </div>
+              <div>
+                <label for="manualDir">Direction</label>
+                <select id="manualDir">
+                  <option value="up">Up</option>
+                  <option value="down">Down</option>
+                </select>
+              </div>
+            </div>
+            <div class="row button-row">
+              <button id="manualCall" class="primary">Call Elevator</button>
+            </div>
+          </div>
+
+          <div class="panel-card" id="customEditorSection" style="display:none;">
+            <h2 class="title">Custom Algorithm</h2>
+            <div class="small" style="margin-bottom:6px;">
+              Provide a JS function named <code>decide</code> taking a state object and returning decisions.
+            </div>
+            <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
+            <div class="row button-row">
+              <button id="loadCustom" class="primary">Load Custom Algorithm</button>
+            </div>
           </div>
         </div>
-        <div class="row">
-          <label for="spawnRate">Spawn Rate (ppl/min)</label>
-          <input id="spawnRate" type="range" min="0" max="200" value="40"/>
-        </div>
-        <div class="row">
-          <label></label>
-          <div class="small" id="spawnRateLabel">40 ppl/min</div>
-        </div>
-        <div class="row">
-          <label for="algorithm">Algorithm</label>
-          <select id="algorithm">
-            <option value="nearest">Nearest Car</option>
-            <option value="nearestNonBusy">Nearest Non-Busy Car</option>
-            <option value="exclusiveNearest">Single Responder (Nearest)</option>
-            <option value="collective">Collective (Simple)</option>
-            <option value="zoned">Zoned (Sectorized)</option>
-            <option value="idleLobby">Idle To Lobby</option>
-            <option value="custom">Custom (Editor)</option>
-          </select>
-        </div>
-        <div class="row">
-          <button id="apply" class="primary">Apply & Restart</button>
-          <button id="pause">Pause</button>
-        </div>
-      </div>
-
-      <div class="section">
-        <h1 class="title">Manual Call</h1>
-        <div class="grid-two">
-          <div>
-            <label for="manualFloor">Floor</label>
-            <input id="manualFloor" type="number" min="0" max="49" value="0"/>
-          </div>
-          <div>
-            <label for="manualDir">Direction</label>
-            <select id="manualDir">
-              <option value="up">Up</option>
-              <option value="down">Down</option>
-            </select>
+      </section>
+      <section id="view-crowd" class="view-panel" data-view="crowd" role="tabpanel" aria-labelledby="tab-crowd" aria-hidden="true" tabindex="-1">
+        <div class="panel-scroll">
+          <div class="panel-card">
+            <h2 class="title">Crowd Model</h2>
+            <div class="row">
+              <label for="groundBias">Ground Floor Bias</label>
+              <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
+            </div>
+            <div class="row">
+              <label></label>
+              <div id="groundBiasLabel" class="small">x3.0</div>
+            </div>
+            <div class="row">
+              <label for="toLobbyPct">To Lobby Preference</label>
+              <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
+            </div>
+            <div class="row">
+              <label></label>
+              <div id="toLobbyPctLabel" class="small">70%</div>
+            </div>
           </div>
         </div>
-        <div class="row">
-          <button id="manualCall" class="primary">Call Elevator</button>
+      </section>
+      <section id="view-stats" class="view-panel" data-view="stats" role="tabpanel" aria-labelledby="tab-stats" aria-hidden="true" tabindex="-1">
+        <div class="panel-scroll">
+          <div class="panel-card">
+            <h2 class="title">Overview</h2>
+            <div class="stats">
+              <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
+              <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
+              <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
+              <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
+            </div>
+          </div>
+          <div class="panel-card">
+            <h2 class="title">Fleet</h2>
+            <div id="fleetList" class="fleet-list"></div>
+          </div>
+          <div class="panel-card">
+            <h2 class="title">Floor Calls</h2>
+            <div id="floorCalls" class="floor-calls"></div>
+          </div>
         </div>
-      </div>
-
-      <div class="section" id="customEditorSection" style="display:none;">
-        <div class="small" style="margin-bottom:6px;">
-          Provide a JS function named <code>decide</code> taking a state object and returning decisions.
-        </div>
-        <textarea id="customCode" class="code-editor" spellcheck="false"></textarea>
-        <div class="row">
-          <button id="loadCustom" class="primary">Load Custom Algorithm</button>
-        </div>
-      </div>
-    </div>
-
-    <div class="screen" data-screen="crowd" id="screen-crowd" role="tabpanel" aria-labelledby="tab-crowd">
-      <div class="section">
-        <h1 class="title">Crowd Model</h1>
-        <div class="row">
-          <label for="groundBias">Ground Floor Bias</label>
-          <input id="groundBias" type="range" min="1" max="6" step="0.5" value="3"/>
-        </div>
-        <div class="row"><label></label><div id="groundBiasLabel" class="small">x3.0</div></div>
-        <div class="row">
-          <label for="toLobbyPct">To Lobby Preference</label>
-          <input id="toLobbyPct" type="range" min="0" max="100" value="70"/>
-        </div>
-        <div class="row"><label></label><div id="toLobbyPctLabel" class="small">70%</div></div>
-      </div>
-    </div>
-
-    <div class="screen" data-screen="stats" id="screen-stats" role="tabpanel" aria-labelledby="tab-stats">
-      <div class="section">
-        <div class="stats">
-          <div class="stat"><div class="label">Completed</div><div id="statCompleted" class="value">0</div></div>
-          <div class="stat"><div class="label">Throughput (min)</div><div id="statThroughput" class="value">0</div></div>
-          <div class="stat"><div class="label">Avg Wait (s)</div><div id="statAvgWait" class="value">0</div></div>
-          <div class="stat"><div class="label">Max Wait (s)</div><div id="statMaxWait" class="value">0</div></div>
-        </div>
-      </div>
-
-      <div class="section">
-        <h1 class="title">Fleet</h1>
-        <div id="fleetList" class="fleet-list"></div>
-      </div>
-
-      <div class="section">
-        <h1 class="title">Floor Calls</h1>
-        <div id="floorCalls" class="floor-calls"></div>
-      </div>
-    </div>
+      </section>
+    </main>
   </div>
 `
 

--- a/src/style.css
+++ b/src/style.css
@@ -50,126 +50,6 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
-/* App layout overrides for the simulator */
-html, body, #app { height: 100%; }
-
-#app {
-  display: grid;
-  grid-template-columns: 1fr 340px;
-  grid-template-rows: 100%;
-  gap: 0;
-  height: 100%;
-  max-width: none;
-  padding: 0;
-  width: 100%;
-}
-
-#gameParent {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-}
-
-#sidebar {
-  display: flex;
-  flex-direction: column;
-  background: #151a21;
-  border-left: 1px solid #1f2630;
-  padding: 18px 20px 96px;
-  overflow-y: auto;
-  text-align: left;
-  gap: 24px;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-}
-
-.sidebar-header {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-bottom: 4px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid #1f2630;
-}
-
-.tab-bar {
-  display: none;
-  gap: 8px;
-  background: #10141b;
-  border: 1px solid #1f2630;
-  border-radius: 999px;
-  padding: 4px;
-}
-
-.tab-button {
-  border-radius: 999px;
-  border-color: #1f2630;
-  background: #11151b;
-  color: #a5b0bf;
-  flex: 1;
-  padding: 0.45em 0.8em;
-  font-size: 0.9rem;
-}
-
-.tab-button.active {
-  background: #173047;
-  border-color: #21435e;
-  color: #e7ecf3;
-}
-
-h1.title {
-  font-size: 18px;
-  margin: 0 0 12px;
-}
-
-.screen {
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-}
-
-.screen:not(.active) {
-  transition: none;
-}
-
-.section { margin: 0; }
-
-.row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 8px 0;
-}
-
-label {
-  color: #a5b0bf;
-  font-size: 12px;
-}
-
-.row label {
-  flex: 0 0 140px;
-}
-
-.row > *:not(label) {
-  flex: 1;
-}
-
-.row button {
-  flex: 1;
-}
-
-input[type="range"], select, input[type="number"], textarea {
-  width: 100%;
-  background: #11151b;
-  color: #e7ecf3;
-  border: 1px solid #2a2f3a;
-  border-radius: 6px;
-  padding: 8px;
-  font: inherit;
-}
-
-input[type="range"] { padding: 0; }
 button.primary {
   background: #173047;
   border-color: #21435e;
@@ -180,117 +60,379 @@ button.primary:hover {
   background: #1c3c59;
 }
 
+html,
+body,
+#app {
+  height: 100%;
+}
+
+#app {
+  height: 100%;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  background: #0f1216;
+  color: #e7ecf3;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 28px;
+  background: #11151b;
+  border-bottom: 1px solid #1f2630;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+  position: relative;
+  z-index: 4;
+}
+
+.brand {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.brand-title {
+  font-size: 1.45rem;
+  font-weight: 600;
+}
+
+.brand-subtitle {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #7f8ba0;
+}
+
+.nav-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.nav-link {
+  border-radius: 999px;
+  border: 1px solid #1f2630;
+  background: #151a21;
+  color: #a5b0bf;
+  padding: 0.55em 1.15em;
+  font-size: 0.95rem;
+  transition: transform 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.nav-link:hover {
+  transform: translateY(-1px);
+}
+
+.nav-link.active {
+  background: #1d3a55;
+  border-color: #21435e;
+  color: #e7ecf3;
+}
+
+#view-root {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background: #0f1216;
+}
+
+.simulation-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  display: flex;
+  background: #0f1216;
+}
+
+#gameParent {
+  flex: 1;
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+#gameParent canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  touch-action: none;
+}
+
+.view-panel {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: none;
+  overflow-y: auto;
+  padding: 32px 32px 120px;
+  background: rgba(16, 20, 27, 0.96);
+  backdrop-filter: blur(6px);
+}
+
+.view-panel.active {
+  display: block;
+}
+
+.panel-scroll {
+  max-width: 760px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.panel-card {
+  background: #11151b;
+  border: 1px solid #1f2630;
+  border-radius: 12px;
+  padding: 24px 24px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.35);
+}
+
+.panel-card code {
+  background: #0d1117;
+  border: 1px solid #1f2630;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-size: 12px;
+}
+
+.title {
+  font-size: 20px;
+  margin: 0;
+}
+
+.section-title {
+  font-size: 16px;
+  margin: 0 0 4px;
+  color: #a5b0bf;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.row label {
+  flex: 0 0 160px;
+  color: #a5b0bf;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.row > *:not(label) {
+  flex: 1;
+}
+
+.row button {
+  flex: 1;
+}
+
+.row.button-row {
+  justify-content: flex-end;
+  gap: 10px;
+}
+
 .grid-two {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 8px;
+  gap: 12px;
+}
+
+label {
+  color: #a5b0bf;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.small {
+  font-size: 12px;
+  color: #a5b0bf;
+}
+
+input[type='range'],
+select,
+input[type='number'],
+textarea {
+  width: 100%;
+  background: #11151b;
+  color: #e7ecf3;
+  border: 1px solid #2a2f3a;
+  border-radius: 6px;
+  padding: 8px;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+input[type='range'] {
+  padding: 0;
+}
+
+textarea.code-editor {
+  width: 100%;
+  min-height: 180px;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
 }
 
 .stats {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 10px;
 }
+
 .stat {
   background: #11151b;
   border: 1px solid #2a2f3a;
   border-radius: 6px;
-  padding: 10px;
-}
-.stat .label { color: #a5b0bf; font-size: 11px; }
-.stat .value { font-size: 16px; margin-top: 4px; }
-
-.danger { color: #ff6b6b; }
-.ok { color: #58d68d; }
-.warn { color: #ffd166; }
-.small { font-size: 12px; color: #a5b0bf; }
-#sidebar .row .small { text-align: right; }
-
-.code-editor {
-  width: 100%;
-  min-height: 160px;
-  resize: vertical;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    "Liberation Mono", "Courier New", monospace;
+  padding: 12px;
 }
 
-/* Fleet list */
-.fleet-list { display: grid; gap: 6px; }
+.stat .label {
+  color: #a5b0bf;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat .value {
+  font-size: 18px;
+  margin-top: 6px;
+  font-weight: 600;
+}
+
+.danger {
+  color: #ff6b6b;
+}
+
+.ok {
+  color: #58d68d;
+}
+
+.warn {
+  color: #ffd166;
+}
+
+.fleet-list {
+  display: grid;
+  gap: 10px;
+}
+
 .fleet-row {
   display: grid;
-  grid-template-columns: 38px 1fr 56px 64px;
+  grid-template-columns: 46px 1fr 72px 90px;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
   background: #11151b;
   border: 1px solid #2a2f3a;
-  border-radius: 6px;
-  padding: 8px;
+  border-radius: 8px;
+  padding: 10px;
 }
+
 .chip {
   background: #0d1117;
   border: 1px solid #2a2f3a;
   border-radius: 999px;
-  padding: 2px 8px;
+  padding: 2px 10px;
   font-size: 12px;
   color: #e7ecf3;
   text-align: center;
 }
-.dir-up { color: #58d68d; }
-.dir-down { color: #ff6b6b; }
-.dir-idle { color: #a5b0bf; }
 
-.bar { background:#0b0e13; border:1px solid #2a2f3a; border-radius:4px; height:10px; overflow:hidden; }
-.bar-fill { background:#ffd166; height:100%; width:0%; }
+.dir-up {
+  color: #58d68d;
+}
 
-.floor-calls { display:grid; gap:6px; }
-.call-row { display:flex; justify-content:space-between; align-items:center; background:#11151b; border:1px solid #2a2f3a; border-radius:6px; padding:6px 8px; }
-.badge { border:1px solid #2a2f3a; border-radius:999px; padding:2px 8px; font-size:12px; }
-.badge.up { color:#58d68d; }
-.badge.down { color:#ff6b6b; }
+.dir-down {
+  color: #ff6b6b;
+}
 
-@media (max-width: 900px) {
-  #app {
+.dir-idle {
+  color: #a5b0bf;
+}
+
+.bar {
+  background: #0b0e13;
+  border: 1px solid #2a2f3a;
+  border-radius: 4px;
+  height: 12px;
+  overflow: hidden;
+}
+
+.bar-fill {
+  background: #ffd166;
+  height: 100%;
+  width: 0%;
+}
+
+.floor-calls {
+  display: grid;
+  gap: 8px;
+}
+
+.call-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #11151b;
+  border: 1px solid #2a2f3a;
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+
+.badge {
+  border: 1px solid #2a2f3a;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 12px;
+}
+
+.badge.up {
+  color: #58d68d;
+}
+
+.badge.down {
+  color: #ff6b6b;
+}
+
+@media (max-width: 1024px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nav-bar {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 820px) {
+  .view-panel {
+    padding: 28px 22px 96px;
+  }
+
+  .panel-card {
+    padding: 20px 20px 18px;
+  }
+
+  .grid-two {
     grid-template-columns: 1fr;
-    grid-template-rows: minmax(280px, 55vh) minmax(0, 1fr);
-    height: auto;
-  }
-
-  #gameParent {
-    min-height: 280px;
-  }
-
-  #sidebar {
-    border-left: none;
-    border-top: 1px solid #1f2630;
-    padding: 16px 16px 80px;
-    gap: 20px;
-  }
-
-  .sidebar-header {
-    position: sticky;
-    top: 0;
-    background: #151a21;
-    padding-top: 8px;
-    padding-bottom: 16px;
-    margin-bottom: 0;
-    z-index: 2;
-  }
-
-  .tab-bar {
-    display: flex;
-  }
-
-  .tab-button {
-    font-size: 1rem;
-    padding: 0.55em 0.9em;
-  }
-
-  .screen {
-    display: none;
-  }
-
-  .screen.active {
-    display: flex;
   }
 
   .row {
@@ -306,26 +448,14 @@ button.primary:hover {
     width: 100%;
   }
 
-  .row label:empty {
-    display: none;
-  }
-
-  .row .small {
-    text-align: left;
-  }
-
-  .grid-two {
-    grid-template-columns: 1fr;
-  }
-
-  .stats {
-    grid-template-columns: 1fr;
+  .row.button-row {
+    justify-content: stretch;
   }
 
   .fleet-row {
-    display: flex;
-    flex-direction: column;
+    grid-template-columns: 1fr;
     align-items: flex-start;
+    gap: 8px;
   }
 
   .call-row {
@@ -336,19 +466,20 @@ button.primary:hover {
 }
 
 @media (max-width: 600px) {
-  #gameParent {
-    min-height: 240px;
+  .app-header {
+    padding: 16px 18px;
   }
 
-  .tab-bar {
-    padding: 6px;
+  .nav-bar {
+    gap: 8px;
   }
 
-  button {
-    font-size: 1rem;
+  .nav-link {
+    flex: 1 1 45%;
+    justify-content: center;
   }
 
-  #sidebar {
-    padding: 14px 14px 72px;
+  .view-panel {
+    padding: 24px 16px 84px;
   }
 }


### PR DESCRIPTION
## Summary
- restructure the app into a navigation-driven shell with dedicated controls, crowd, and stats overlays that keep the simulation running in the background
- refresh styling for the new header, overlays, and form cards while preserving responsive layouts and data displays
- add camera pan/zoom interactions with wheel and pinch gestures so the simulation can be inspected closely even while other views are selected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0b16df21c832681020a68c6eb1390